### PR TITLE
Fixed Index Type subtraction

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -569,7 +569,7 @@ macro_rules! __define_index_type_inner {
             type Output = $type;
             #[inline]
             fn sub(self, other: $type) -> $type {
-                $type::new(other.index().wrapping_sub(self.index()))
+                $type::new(self.index().wrapping_sub(other.index()))
             }
         }
 


### PR DESCRIPTION
I found a small bug while using this crate.
When subtracting two index types the subtraction happens the wrong way around.
# Expected behaviour: 

```rust
let x = foo::new(2);
let y = foo::new(1);
assert_eq!(x-y, foo::new(1));
```

# Actual behaviour

```rust
let x = foo::new(2);
let y = foo::new(1);
// if foo uses a smaller index type this panics
assert_eq!(x-y, foo::new(usize::MAX-1));
```

This PR fixes this bug by changing the `define_index_type!` macro appropriately

I suggest merging this quickly and possibly yanking the old version as this can cause serious bugs
