### PR TITLE
Make more functions const in index types

### DIFF
--- a/example_generated/example_generated.rs
+++ b/example_generated/example_generated.rs
@@ -54,12 +54,12 @@ impl CoolIndex {
     }
     /// Get the wrapped index as a usize.
     #[inline(always)]
-    pub fn index(self) -> usize {
+    pub const fn index(self) -> usize {
         self._raw as usize
     }
     /// Get the wrapped index.
     #[inline(always)]
-    pub fn raw(self) -> u32 {
+    pub const fn raw(self) -> u32 {
         self._raw
     }
     /// Asserts `v <= Self::MAX_INDEX` unless Self::CHECKS_MAX_INDEX is false.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -442,13 +442,13 @@ macro_rules! __define_index_type_inner {
 
             /// Get the wrapped index as a usize.
             #[inline(always)]
-            $v fn index(self) -> usize {
+            $v const fn index(self) -> usize {
                 self._raw as usize
             }
 
             /// Get the wrapped index.
             #[inline(always)]
-            $v fn raw(self) -> $raw {
+            $v const fn raw(self) -> $raw {
                 self._raw
             }
 


### PR DESCRIPTION
Having eg `index()` be `const` makes constants of an index type more useful. For instance, you can define an array using the constant as the array length, using `index` to unwrap to a `usize`.