### PR TITLE
Implement `Idx` for `u8`, `u16`, `u32`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,16 +216,6 @@ impl Idx for u32 {
     }
 }
 
-impl Idx for usize {
-    fn from_usize(idx: usize) -> Self {
-        idx
-    }
-
-    fn index(self) -> usize {
-        self
-    }
-}
-
 /// A macro equivalent to the stdlib's `vec![]`, but producing an `IndexVec`.
 #[macro_export]
 macro_rules! index_vec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::{Borrow, BorrowMut};
+use core::convert::TryInto;
 use core::fmt;
 use core::fmt::Debug;
 use core::hash::Hash;
@@ -183,6 +184,46 @@ pub trait Idx: Copy + 'static + Ord + Debug + Hash {
 
     /// Get the underlying index. This is equivalent to `Into<usize>`
     fn index(self) -> usize;
+}
+
+impl Idx for u8 {
+    fn from_usize(idx: usize) -> Self {
+        idx.try_into().unwrap()
+    }
+
+    fn index(self) -> usize {
+        self.into()
+    }
+}
+
+impl Idx for u16 {
+    fn from_usize(idx: usize) -> Self {
+        idx.try_into().unwrap()
+    }
+
+    fn index(self) -> usize {
+        self.into()
+    }
+}
+
+impl Idx for u32 {
+    fn from_usize(idx: usize) -> Self {
+        idx.try_into().unwrap()
+    }
+
+    fn index(self) -> usize {
+        self as usize
+    }
+}
+
+impl Idx for usize {
+    fn from_usize(idx: usize) -> Self {
+        idx
+    }
+
+    fn index(self) -> usize {
+        self
+    }
 }
 
 /// A macro equivalent to the stdlib's `vec![]`, but producing an `IndexVec`.


### PR DESCRIPTION
For my use case, I have a bunch of `IndexVec<I, T>` where `I: Idx` is a custom type, but I also need a few `IndexVec<u32, T>` as well. This PR implements `Idx` for the primitive types `u8`, `u16`, and `u32`.

The implementations for `u8` and `u16` should be uncontroversial. The one for `u32` is a bit less clear since technically Rust does support 16-bit platforms, but it's the only one from this PR that I actually need 😅