### PR TITLE
Add support for non-zero unsigned integer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1", optional = true }
 rkyv = { version = "0.7", optional = true }
+paste = "1.0.15"
 
 [features]
 example_generated = []

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Planned is a bit strong but here are the things I would find useful.
 - Allow use of indices for string types (the primary benefit here would
   probably be the ability to e.g. use u32 without too much pain rather than
   mixing up indices from different strings -- but you never know!)
-- Allow index types such as NonZeroU32 and such, if it can be done sanely.
 - ...
 
 ## License

--- a/src/baseidx.rs
+++ b/src/baseidx.rs
@@ -1,0 +1,174 @@
+use core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize};
+
+/// Represents a type which can be used as the base index type of a newly defined [`Idx`] type.
+///
+/// It is implemented for all common unsigned integer types: `u8`, `u16`, `u32`, `u64` and `usize`.
+///
+/// It also implemented for all common non-zero unsigned integer types: `NonZeroU8`, `NonZeroU16`, `NonZeroU32`, `NonZeroU64` and
+/// `NonZeroUsize`.
+/// Using non-zero types can be useful for improving performance since it allows the compiler to perform niche optimization in many
+/// situations (e.g `size_of::<Option<NonZeroUsize>>() == size_of::<NonZeroUsize>()`).
+///
+/// For non-zero unsigned integer types, the index value is actually represented internally as `index + 1`, such that index `0` is still
+/// a valid index, and the max value is instead the value that is impossible to represent.
+///
+/// So, for example:
+/// - `<NonZeroUsize as BaseIdx>::Converter::from_usize_unchecked(0)` will return `NonZeroUsize(1)`
+/// - `<NonZeroUsize as BaseIdx>::Converter::from_usize_unchecked(16)` will return `NonZeroUsize(17)`
+/// - `<NonZeroUsize as BaseIdx>::Converter::from_usize(usize::MAX)` will return panic, since after overflow it would theoretically result
+///   in `NonZeroUsize(0)`, which is undefined behaviour.
+///
+/// And, for example:
+/// - `<NonZeroUsize as BaseIdx>::Converter::to_usize(NonZeroUsize(1))` will return `Some(NonZeroUsize(0))`
+/// - `<NonZeroUsize as BaseIdx>::Converter::to_usize(NonZeroUsize(24))` will return `Some(NonZeroUsize(23))`
+///
+/// [`Idx`]: crate::Idx
+pub trait BaseIdx: Sized {
+    /// A converter type, used to convert this value to and from `usize`.
+    ///
+    /// We could just add conversion functions directly on this trait, (e.g `fn from_usize(v: usize) -> Option<Self>`), but trait
+    /// functions can't be called in const contexts, and we want to be able to convert this type to/from `usize` in const contexts.
+    ///
+    /// Additionally, we can't implement the const conversion functions directly on the type itself, since the type is most likely a
+    /// builtin or standard library type (e.g `usize`, `NonZeroUsize`), so we can't implement functions directly on it.
+    ///
+    /// So what we instead do is implement an additional converter type for every base index type, and then implement the const conversion
+    /// functions on that converter type.
+    ///
+    /// When we then want to convert the base index type to/from `usize`, we call one of the conversion functions of the converter type,
+    /// for example: `<NonZeroU16 as BaseIdx>::Converter::from_usize(5_usize)`, which works even in const contexts.
+    ///
+    /// The functions that are expected to be implemented on the converter type are (`I` represents the base index type):
+    /// - `const fn from_usize_unchecked(idx: usize) -> I` - Convert from `usize` to the base index type while skipping as many runtime
+    ///   bounds checks as possible. May still panic in some situations where returning the `I` value that corresponds to the provided
+    ///   `usize` value would cause undefined behaviour.
+    /// - `const fn to_usize(value: I) -> Option<usize>` - Convert from the base index type to `usize`, while performing runtime bounds
+    ///   checking. returns `None` if the provided value is too big to fit in a `usize`.
+    type Converter;
+
+    /// The maximum value for this base index type.
+    const MAX: Self;
+
+    /// The maximum value for this base index type, as a `usize`.
+    const MAX_USIZE: usize;
+}
+
+macro_rules! impl_base_idx_for_uint {
+    {$t: ty} => {
+        paste::paste! {
+            pub struct [<$t:camel BaseIdxConverter>];
+            impl [<$t:camel BaseIdxConverter>] {
+                #[inline]
+                pub const fn from_usize(idx: usize) -> Option<$t> {
+                    // We can't use `try_into` or even the `?` operator here since we are in a const context.
+                    // So, we must perform manual bounds checking.
+                    if $t::MAX > usize::MAX as $t {
+                        // $t is bigger than usize, so we can always just safely convert a usize to $t
+                        Some(idx as $t)
+                    } else {
+                        // $t is smaller than usize, so the conversion may fail
+                        if idx <= $t::MAX as usize {
+                            Some(idx as $t)
+                        } else {
+                            None
+                        }
+                    }
+                }
+
+                #[inline]
+                pub const fn from_usize_unchecked(idx: usize) -> $t {
+                    idx as $t
+                }
+
+                #[inline]
+                pub const fn to_usize(value: $t) -> Option<usize> {
+                    // We can't use `try_into` or even the `?` operator here since we are in a const context.
+                    // So, we must perform manual bounds checking.
+                    if $t::MAX > usize::MAX as $t {
+                        // $t is bigger than usize, we the conversion may fail
+                        if value <= usize::MAX as $t {
+                            Some(value as usize)
+                        } else {
+                            None
+                        }
+                    } else {
+                        // $t is smaller than usize, so we can always just safely convert it to a usize
+                        Some(value as usize)
+                    }
+                }
+            }
+            impl BaseIdx for $t {
+                type Converter = [<$t:camel BaseIdxConverter>];
+                const MAX: Self = Self::MAX;
+                const MAX_USIZE: usize = Self::MAX as usize;
+            }
+        }
+    };
+}
+impl_base_idx_for_uint! {u8}
+impl_base_idx_for_uint! {u16}
+impl_base_idx_for_uint! {u32}
+impl_base_idx_for_uint! {u64}
+impl_base_idx_for_uint! {usize}
+
+/// A manual implementation of the `?` operator for `Option<T>` types, which unlike the `?` operator actually works in const contexts.
+macro_rules! opt_try {
+    ($x: expr) => {
+        (match $x {
+            Some(___v) => ___v,
+            None => return None
+        })
+    };
+}
+
+macro_rules! impl_base_idx_for_non_zero_uint {
+    {$non_zero_uint: ty, $regular_uint: ty} => {
+        paste::paste! {
+            pub struct [<$non_zero_uint BaseIdxConverter>];
+            impl [<$non_zero_uint BaseIdxConverter>] {
+                #[inline]
+                pub const fn from_usize(idx: usize) -> Option<$non_zero_uint> {
+                    Some(
+                        // SAFETY: we added 1 and it didn't overflow, so the value is non-zero
+                        unsafe {
+                            $non_zero_uint::new_unchecked(
+                                opt_try!(<$regular_uint as BaseIdx>::Converter::from_usize(
+                                    opt_try!(idx.checked_add(1))
+                                ))
+                            )
+                        },
+                    )
+                }
+
+                #[inline]
+                pub const fn from_usize_unchecked(idx: usize) -> $non_zero_uint {
+                    // We make a best effort in making this logic "unchecked".
+                    //
+                    // We don't check the addition and the cast, but we do check that the result is non zero.
+                    //
+                    // This is very important since creating a non-zero object with a value of zero can cause some really bad undefined
+                    // behaviour, and this function is not marked `unsafe`, so it should not cause any such UB under any circumstances.
+                    $non_zero_uint::new((idx + 1) as $regular_uint).unwrap()
+                }
+
+                #[inline]
+                pub const fn to_usize(value: $non_zero_uint) -> Option<usize> {
+                    <$regular_uint as BaseIdx>::Converter::to_usize(
+                        // SAFETY: the value is non-zero so subtracting 1 can't underflow
+                        unsafe { value.get().unchecked_sub(1) }
+                    )
+                }
+            }
+            impl BaseIdx for $non_zero_uint {
+                type Converter = [<$non_zero_uint BaseIdxConverter>];
+                const MAX: Self = Self::MAX;
+                const MAX_USIZE: usize = Self::MAX.get() as usize;
+            }
+        }
+    };
+}
+impl_base_idx_for_non_zero_uint! {NonZeroU8, u8}
+impl_base_idx_for_non_zero_uint! {NonZeroU16, u16}
+impl_base_idx_for_non_zero_uint! {NonZeroU32, u32}
+impl_base_idx_for_non_zero_uint! {NonZeroU64, u64}
+impl_base_idx_for_non_zero_uint! {NonZeroUsize, usize}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,6 @@
 //! - Allow use of indices for string types (the primary benefit here would
 //!   probably be the ability to e.g. use u32 without too much pain rather than
 //!   mixing up indices from different strings -- but you never know!)
-//! - Allow index types such as NonZeroU32 and such, if it can be done sanely.
 //! - ...
 //!
 #![allow(clippy::partialeq_ne_impl)]
@@ -145,8 +144,10 @@ use core::ops::Range;
 use core::slice;
 mod idxslice;
 mod indexing;
+mod baseidx;
 pub use idxslice::{IndexBox, IndexSlice};
 pub use indexing::{IdxRangeBounds, IdxSliceIndex};
+pub use baseidx::BaseIdx;
 
 #[macro_use]
 mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,7 +52,7 @@
 ///
 /// Assert if anything tries to construct an index above that value.
 ///
-/// By default, this is `$raw_type::max_value() as usize`, e.g. we check that
+/// By default, this is `<$raw_type as BaseIdx>::MAX_USIZE`, e.g. we check that
 /// our cast from `usize` to our wrapper is lossless, but we assume any all
 /// instance of `$raw_type` is valid in this index domain.
 ///
@@ -166,7 +166,7 @@ macro_rules! define_index_type {
             @derives [#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]]
             @decl [$v struct $type ($raw)]
             @debug_fmt ["{}"]
-            @max [(<$raw>::max_value() as usize)]
+            @max [(<$raw as $crate::BaseIdx>::MAX_USIZE)]
             @no_check_max [false]
         }
     };
@@ -464,7 +464,7 @@ macro_rules! __define_index_type_inner {
             /// Construct this index type from the wrapped integer type.
             #[inline(always)]
             $v fn from_raw(value: $raw) -> Self {
-                Self::from_usize(value as usize)
+                Self::from_usize(<$raw as $crate::BaseIdx>::Converter::to_usize(value).unwrap())
             }
 
             /// Construct this index type from one in a different domain
@@ -476,7 +476,7 @@ macro_rules! __define_index_type_inner {
             /// Construct from a usize without any checks.
             #[inline(always)]
             $v const fn from_usize_unchecked(value: usize) -> Self {
-                Self { _raw: value as $raw }
+                Self { _raw: <$raw as $crate::BaseIdx>::Converter::from_usize_unchecked(value) }
             }
 
             /// Construct from the underlying type without any checks.
@@ -489,13 +489,13 @@ macro_rules! __define_index_type_inner {
             #[inline]
             $v fn from_usize(value: usize) -> Self {
                 Self::check_index(value as usize);
-                Self { _raw: value as $raw }
+                Self { _raw: <$raw as $crate::BaseIdx>::Converter::from_usize_unchecked(value) }
             }
 
             /// Get the wrapped index as a usize.
             #[inline(always)]
             $v const fn index(self) -> usize {
-                self._raw as usize
+                <$raw as $crate::BaseIdx>::Converter::to_usize(self._raw).unwrap()
             }
 
             /// Get the wrapped index.
@@ -511,8 +511,6 @@ macro_rules! __define_index_type_inner {
                     $crate::__max_check_fail(v, Self::MAX_INDEX);
                 }
             }
-
-            const _ENSURE_RAW_IS_UNSIGNED: [(); 0] = [(); <$raw>::MIN as usize];
         }
 
         impl core::fmt::Debug for $type {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,19 @@
 #![allow(clippy::assertions_on_constants, clippy::eq_op)]
 
+use std::num::{NonZeroU8, NonZeroUsize};
+
 use index_vec::{index_vec, IndexSlice, IndexVec};
 
 index_vec::define_index_type! {
     pub struct USize16 = usize;
     MAX_INDEX = u16::MAX as usize;
     DEFAULT = USize16::from_raw_unchecked(usize::MAX);
+}
+
+index_vec::define_index_type! {
+    pub struct NonZeroUsize16 = NonZeroUsize;
+    MAX_INDEX = u16::MAX as usize;
+    DEFAULT = NonZeroUsize16::from_raw_unchecked(NonZeroUsize::new(usize::MAX).unwrap());
 }
 
 index_vec::define_index_type! {
@@ -45,6 +53,10 @@ index_vec::define_index_type! {
 
 index_vec::define_index_type! {
     pub struct SmallChecked = u8;
+}
+
+index_vec::define_index_type! {
+    pub struct SmallNonZeroChecked = NonZeroU8;
 }
 
 index_vec::define_index_type! {
@@ -106,9 +118,11 @@ fn test_idx_checks1() {
     assert_eq!(SmallCheckedEarly::from_raw_unchecked(0xff).raw(), 0xff);
 
     assert!(SmallChecked::CHECKS_MAX_INDEX);
+    assert!(SmallNonZeroChecked::CHECKS_MAX_INDEX);
     assert!(SmallCheckedEarly::CHECKS_MAX_INDEX);
 
     assert_eq!(SmallChecked::MAX_INDEX, 255);
+    assert_eq!(SmallNonZeroChecked::MAX_INDEX, 255);
     assert_eq!(SmallCheckedEarly::MAX_INDEX, 0x7f);
 
     assert!(!SmallUnchecked::CHECKS_MAX_INDEX);
@@ -129,6 +143,15 @@ fn test_idx_checks2() {
     let v = SmallChecked::from_usize(255);
     assert_eq!(v, 255);
     let v = SmallChecked::from_usize(0);
+    assert_eq!(v, 0);
+
+    let v = SmallNonZeroChecked::from_raw(NonZeroU8::new(150).unwrap());
+    // Note that a non-zero value with internal representation 150 actually represents index 149 due to how non-zero integers are used
+    // to represent indices (the internally store `index + 1`).
+    assert_eq!(v, 149);
+    let v = SmallNonZeroChecked::from_usize(150);
+    assert_eq!(v, 150);
+    let v = SmallNonZeroChecked::from_usize(0);
     assert_eq!(v, 0);
 
     let v = SmallCheckedEarly::from_usize(0x7f);
@@ -155,8 +178,13 @@ fn test_idx_checks2() {
     assert_eq!(v.raw(), 300usize as u8);
     let v = SmallChecked::from_usize_unchecked(300);
     assert_eq!(v.raw(), 300usize as u8);
+    let v = SmallNonZeroChecked::from_usize_unchecked(300);
+    assert_eq!(v.raw().get(), (300usize as u8) + 1);
 
     assert_eq!(<USize16 as Default>::default().index(), usize::MAX);
+    // Note that due to how non zero integers represent indices (the store `index + 1` internally), the max index actually represents
+    // index `usize::MAX - 1`.
+    assert_eq!(<NonZeroUsize16 as Default>::default().index(), usize::MAX - 1);
 
     let v = ZeroMaxIgnore::new((u16::MAX as usize) + 1);
     assert_eq!(v, 0);
@@ -567,3 +595,28 @@ fn test_splits() {
     assert!(v.split_first_mut().is_none());
     assert!(v.split_last_mut().is_none());
 }
+
+#[test]
+fn test_non_zero_indices() {
+    let v: IndexVec<SmallNonZeroChecked, i32> = index_vec![5, 22];
+    let indices: Vec<SmallNonZeroChecked> = v.indices().collect();
+    assert_eq!(indices, [SmallNonZeroChecked::new(0), SmallNonZeroChecked::new(1)]);
+
+    // Internally, each non zero index should store the value `index + 1`.
+    let inner_values: Vec<u8> = v.indices().map(|index| index.raw().get()).collect();
+    assert_eq!(inner_values, [1, 2]);
+
+    // Regardless of the internal representation, the returned index values should be the real index values.
+    let index_values: Vec<usize> = v.indices().map(|index| index.index()).collect();
+    assert_eq!(index_values, [0, 1]);
+}
+
+#[test]
+fn test_non_zero_idx_get() {
+    let v: IndexVec<SmallNonZeroChecked, i32> = index_vec![5, 22, 123];
+    assert_eq!(v[SmallNonZeroChecked::new(1)], 22);
+
+    // Internally, each non zero index should store the value `index + 1`, so accessing raw index value 1 should actually access index 0.
+    assert_eq!(v[SmallNonZeroChecked::from_raw(NonZeroU8::new(1).unwrap())], 5);
+}
+


### PR DESCRIPTION
Currently, non-zero unsigned integer types (e.g `NonZeroU32`) can't be used as the underlying type of a custom index type defined using `define_index_type!`, only plain unsigned integer types can be used (e.g `u32`).

Add support for using all common non-zero unsigned integer types as the underlying type of a custom index type.

This is done by adding a new trait called `BaseIdx` which represents any type that can be used as the base index type of a custom index type.

the `BaseIdx` trait encompasses all the behaviour required for the underlying index type by the `define_index_type!` macro.

This allows the `define_index_type!` to support any arbitrary underlying index type as long as it implementes the `BaseIdx` trait, so additional base index types can easily be added in the future.

Internally, when converting an index to a non-zero integer, we just store the value `index + 1` instead of the direct index value.

This is done so that index `0` is a valid index even though the type can't really hold the value `0` internally (it is a non-zero type).

As a consequence, the max value for the integer type (e.g `usize::MAX` for `NonZeroUsize`) is not a valid index for the non-zero integer type, since adding `1` to the index in this case overflows back to `0`, which can't be represented as a non-zero value.

But, this is a good trade-off, since an index with value `0` is much more common than an index with a value equal to the max value of the integer type.