### PR TITLE
Add missing explicit lifetime annotation in the return type of IndexVec::splice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         &mut self,
         range: R,
         replace_with: It,
-    ) -> vec::Splice<<It as IntoIterator>::IntoIter>
+    ) -> vec::Splice<'_, <It as IntoIterator>::IntoIter>
     where
         It: IntoIterator<Item = T>,
         R: IdxRangeBounds<I>,


### PR DESCRIPTION
Compiling the current code with a new rust compiler yields the following warning:
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/lib.rs:289:9
    |
289 |         &mut self,
    |         ^^^^^^^^^ the lifetime is elided here
...
292 |     ) -> vec::Splice<<It as IntoIterator>::IntoIter>
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
292 |     ) -> vec::Splice<'_, <It as IntoIterator>::IntoIter>
    |                      +++

warning: `index_vec` (lib) generated 1 warning (run `cargo fix --lib -p index_vec` to apply 1 suggestion)
```

Fix the warning by adding the explicit `'_` annotation as recommended by the compiler.